### PR TITLE
Restart driver if returns non-zero on exit, exit with return 1 if no display found

### DIFF
--- a/src/com.sipradius.QemuTabletDriver.Daemon.plist
+++ b/src/com.sipradius.QemuTabletDriver.Daemon.plist
@@ -7,7 +7,10 @@
         <key>RunAtLoad</key>
         <true/>
         <key>KeepAlive</key>
-        <false/>
+        <dict>
+                <key>SuccessfulExit</key>
+                <false/>
+        </dict>
         <key>ProgramArguments</key>
         <array>
             <string>/usr/bin/Qemu Tablet Driver</string>

--- a/src/main.m
+++ b/src/main.m
@@ -643,6 +643,11 @@ int main (int argc, const char * argv[])
         return 1;
     }
 
+    if (!CGMainDisplayID()) {
+        fprintf(stderr, "No display found\n");
+        return 1;
+    }
+
     gLock = [[NSLock alloc] init];
     InitHIDNotifications(vid, pid);
     CFRunLoopRun();


### PR DESCRIPTION
Hi,

I've noticed if a VNC connection to Qemu is active while OS X is booting, mouse movement doesn't work ( may also be the underlying cause of issue #1 ).

I've done some digging and discovered it's because CGMainDisplayID() returns false if there is no Quartz display available when the driver first loads, which happens during boot when the driver is ran ( and continues to return false even if a display is available afterwards, breaking mouse movement until it is killed and re-ran ). 

My patch makes the driver program exit if no display is found, and changes the Daemon plist behaviour to restart the driver if it fails ( so the driver is ran again if there is no Quartz display available the first time it runs ). 

Thanks

Simon
